### PR TITLE
Fix Tests and add test deps to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,8 @@
 	},
 	"autoload": {
 		"classmap": ["classes/"]
+	},
+	"require-dev": {
+		"phpunit/phpunit": "^7.2"
 	}
 }
-

--- a/tests/SyllableTest.php
+++ b/tests/SyllableTest.php
@@ -12,13 +12,18 @@ class SyllableTest extends PHPUnit\Framework\TestCase {
 	 * This method is called before a test is executed.
 	 */
 	protected function setUp() {
-		Syllable::setCacheDir(realpath('cache'));
-		Syllable::setLanguageDir(realpath('languages'));
+		Syllable::setCacheDir(realpath(__DIR__.'/../cache'));
+		Syllable::setLanguageDir(realpath(__DIR__.'/../languages'));
+
+        // Make sure the cache dir exists for our tests.
+        if (!file_exists(__DIR__.'/../cache')) {
+            mkdir(__DIR__.'/../cache');
+        }
 		
 		$this->object = new Syllable;
 	}
 
-	/**
+    /**
 	 * @covers Syllable::setLanguage
 	 * @todo   Implement testSetLanguage().
 	 */


### PR DESCRIPTION
- Added phpunit as dev requirement. 
- Added mkdir in SyllableTest::setUp code for cache directory used by tests

This enables every user to simply

```bash
composer install
vendor/bin/phpunit
```

to test their changes to the codebase.
Before those changes a user had to know that an cache directory must exist.
Not it will be implicitly created if it does not exist, but only for the test-runner.