### PR TITLE
Fixed Typo resulting in Syntax Error - Fixes tests and make the library usable.

### DIFF
--- a/classes/Syllable.php
+++ b/classes/Syllable.php
@@ -350,7 +350,7 @@ class Syllable {
 		$value = $value === null ? '' : "='{$value}'";
 
 		foreach ((array) $attributes as $attribute) {
-			$this->$includes[] = '//*[@' . $attribute . $value . ']';
+			$this->includes[] = '//*[@' . $attribute . $value . ']';
 		}
 	}
 


### PR DESCRIPTION
There was a `$this->$includes` instead of `$this->includes` which let all tests (except PHP7+ - interesting!) fail.