### PR TITLE
Added Coverage Reporting through php-coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /cache/
 /nbproject/
 /debug/
+/build/
+/composer.lock
+/vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,15 @@ matrix:
         dist: precise
     allow_failures:
       - php: hhvm    
-before_script:
-  - mkdir -p cache  
+
+install:
+  - composer install --no-interaction
+script:
+  - mkdir -p cache
+  - mkdir -p build/logs
+  - php vendor/bin/phpunit -c phpunit.xml --coverage-clover build/logs/clover.xml
+
+after_success:
+  - travis_retry php vendor/bin/php-coveralls
+  # or enable logging
+  - travis_retry php vendor/bin/php-coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
 		"classmap": ["classes/"]
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^7.2"
+		"phpunit/phpunit": "^5.7",
+		"php-coveralls/php-coveralls": "^2.1"
 	}
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,4 +5,9 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+  <filter>
+    <whitelist processUncoveredFilesFromWhitelist="true">
+      <directory suffix=".php">classes/</directory>
+    </whitelist>
+  </filter>
 </phpunit>


### PR DESCRIPTION
Added Code Coverage reporting especially regarding #19 it seems to be a good idea to see which functions/code needs to be tested.

Just sign in with Github oAuth on https://coveralls.io/ and enable for your repository after merging.
Also maybe add the coverage badge from coveralls afterwards into the README. 😉 