### PR TITLE
Removed EOL version from Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,13 @@
 language: php
 dist: trusty
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - hhvm
 matrix:
-    include:
-      - php: "5.3"
-        dist: precise
     allow_failures:
-      - php: hhvm    
+      - php: hhvm
 before_script:
-  - mkdir -p cache  
+  - mkdir -p cache


### PR DESCRIPTION
Also added most recent PHP Version to the matrix.
Support for 5.3 on a best-effort basis?
Next Major should deprecate them and move on.