### PR TITLE
Avoid wrapping partial HTML when hyphenated

### DIFF
--- a/classes/Syllable.php
+++ b/classes/Syllable.php
@@ -454,7 +454,7 @@ class Syllable {
 	{
 		$dom = new DOMDocument();
 		$dom->resolveExternals = true;
-		$dom->loadHTML($html);
+		$dom->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
 
 		// filter excludes
 		$xpath = new DOMXPath($dom);

--- a/tests/SyllableTest.php
+++ b/tests/SyllableTest.php
@@ -213,9 +213,9 @@ class SyllableTest extends PHPUnit\Framework\TestCase {
 		$this->object->setHyphen('-');
 		$this->object->setLanguage('en-us');
 
-		$this->assertEquals('<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
-				. "\n" . '<html><body><p>Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text</p></body></html>'
-				. "\n", $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext'));
+		$this->assertEquals(
+				'<p>Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text</p>' . "\n",
+				$this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext'));
 	}
 
 	/**
@@ -281,9 +281,8 @@ class SyllableTest extends PHPUnit\Framework\TestCase {
 
 		// Do not Hypenate content within <b>
 		$this->assertEquals(
-				'<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
-				. "\n" . '<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i></p></body></html>'
-				. "\n", $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
+				'<p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i></p>' . "\n",
+				$this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
 		);
 	}
 
@@ -298,9 +297,8 @@ class SyllableTest extends PHPUnit\Framework\TestCase {
 
 		// Do not Hypenate content within <b>
 		$this->assertEquals(
-				'<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
-				. "\n" . '<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>extravaganza</i></p></body></html>'
-				. "\n", $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
+				'<p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>extravaganza</i></p>' . "\n",
+				$this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
 		);
 	}
 
@@ -317,9 +315,8 @@ class SyllableTest extends PHPUnit\Framework\TestCase {
 
 		// Do not Hypenate content within <b>
 		$this->assertEquals(
-				'<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
-				. "\n" . '<html><body><p>Ridiculously <b class="unsplittable">com-pli-cat-ed</b> metatext <i>extravaganza</i></p></body></html>'
-				. "\n", $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
+				'<p>Ridiculously <b class="unsplittable">com-pli-cat-ed</b> metatext <i>extravaganza</i></p>' . "\n",
+				$this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
 		);
 	}
 
@@ -336,9 +333,8 @@ class SyllableTest extends PHPUnit\Framework\TestCase {
 
 		// Do not Hypenate content within <b>
 		$this->assertEquals(
-				'<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
-				. "\n" . '<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated <i>ex-trav-a-gan-za</i></b> meta-text</p></body></html>'
-				. "\n", $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated <i>extravaganza</i></b> metatext')
+				'<p>Ridicu-lous-ly <b class="unsplittable">complicated <i>ex-trav-a-gan-za</i></b> meta-text</p>' . "\n",
+				$this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated <i>extravaganza</i></b> metatext')
 		);
 	}
 
@@ -353,9 +349,8 @@ class SyllableTest extends PHPUnit\Framework\TestCase {
 
 		// Do not Hypenate content within <b>
 		$this->assertEquals(
-				'<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
-				. "\n" . '<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i></p></body></html>'
-				. "\n", $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
+				'<p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i></p>' . "\n",
+				$this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
 		);
 	}
 
@@ -370,9 +365,8 @@ class SyllableTest extends PHPUnit\Framework\TestCase {
 
 		// Do not Hypenate content within <b>
 		$this->assertEquals(
-				'<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
-				. "\n" . '<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i class="go right ahead">ex-trav-a-gan-za</i></p></body></html>'
-				. "\n", $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i class="go right ahead">extravaganza</i>')
+				'<p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i class="go right ahead">ex-trav-a-gan-za</i></p>' . "\n",
+				$this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i class="go right ahead">extravaganza</i>')
 		);
 	}
 


### PR DESCRIPTION
When only partial HTML should be hyphenated (instead of full documents), DOCTYPE and html/body tags are automatically added. This can be avoided by passing the `LIBXML_HTML_NOIMPLIED` and `LIBXML_HTML_NODEFDTD` flags to `loadHTML`.

I need this for a project where I independently hyphenate HTML chunks. Those are assembled to a full document which in turn needs to be parsed. The additional DOCTYPE, html/body tags everywhere make the HTML hard to parse. 

With this change it works fine in my use case. I don't know about others though.