### PR TITLE
Fixed build status in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Syllable
 ========
 Version 1.4.7
 
-[![Build Status](https://travis-ci.org/vanderlee/phpSyllable.svg)](https://travis-ci.org/vanderlee/phpSyllable)
+[![Build Status](https://travis-ci.org/vanderlee/phpSyllable.svg?branch=master)](https://travis-ci.org/vanderlee/phpSyllable)
 
 Copyright &copy; 2011-2018 Martijn van der Lee.
 MIT Open Source license applies.


### PR DESCRIPTION
We should fix the state within the `README.md` to the master branch.
Otherwise it will show all failings done in the refactoring or any other branch.