### PR TITLE
Possibility to omit Doctype for hyphenateHtml()

### DIFF
--- a/src/Syllable.php
+++ b/src/Syllable.php
@@ -63,6 +63,11 @@ class Syllable
     private $includes = array();
 
     /**
+     * @var int
+     */
+    private $libxmlOptions = 0;
+
+    /**
      * Create a new Syllable class, with defaults
      *
      * @param string $language
@@ -193,6 +198,16 @@ class Syllable
     public function getMinWordLength()
     {
         return $this->min_word_length;
+    }
+
+    /**
+     * Options to use for HTML parsing by libxml
+     * @param integer $libxmlOptions
+     * @see https://www.php.net/manual/de/libxml.constants.php 
+     */
+    public function setLibxmlOptions($libxmlOptions)
+    {
+        $this->libxmlOptions = $libxmlOptions;
     }
 
     private static function initEncoding()
@@ -436,7 +451,7 @@ class Syllable
     {
         $dom = new \DOMDocument();
         $dom->resolveExternals = true;
-        $dom->loadHTML($html);
+        $dom->loadHTML($html, $this->libxmlOptions);
 
         // filter excludes
         $xpath = new \DOMXPath($dom);

--- a/tests/SyllableTest.php
+++ b/tests/SyllableTest.php
@@ -222,6 +222,10 @@ class SyllableTest extends TestCase
         $this->assertEquals('<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
             . "\n" . '<html><body><p>Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text</p></body></html>'
             . "\n", $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext'));
+
+        $this->object->setLibxmlOptions(LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $this->assertEquals('<p>Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text</p>'
+            . "\n", $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext'));
     }
 
     public function testCaseInsensitivity()


### PR DESCRIPTION
This introduces a new method `setLibxmlOptions`
loadHTML() will be called with these options. So, for example:

```php
$syllable->setLibxmlOptions(LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
```

will omit the Doctype and the html tags.