### PR TITLE
Skip GitHub Action scheduler in forks and run tests only in PR context

### DIFF
--- a/.github/workflows/languages.yml
+++ b/.github/workflows/languages.yml
@@ -3,7 +3,7 @@ name: Languages
 on:
   # Run manually on demand.
   workflow_dispatch:
-  # Run automatically on the first day of the month at midnight.
+  # Run automatically on the first day of the month at midnight. Skip running the scheduler in forks (see job condition).
   schedule:
     - cron: '0 0 1 * *'
 
@@ -11,6 +11,7 @@ jobs:
   update:
     name: 'Update languages'
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule' || github.repository == 'vanderlee/phpSyllable'
 
     permissions:
       contents: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,11 +3,8 @@ name: Tests
 on:
   # Run manually on demand.
   workflow_dispatch:
-  # Run automatically on every push and pull request. The runtime is only ~ 30s due to parallelization.
-  push:
-    # Avoid a double run for tagged commits.
-    branches:
-      - '*'
+  # Run automatically when a pull request is created and on each push to it.
+  # The runtime is only ~ 30s due to parallelization.
   pull_request:
 
 jobs:


### PR DESCRIPTION
Running tests on push and pull requests results in duplicate runs on pushes in PRs.

Relates: #59 