### PR TITLE
Allow GitHub Action "Update languages" workflow to bypass reviews

### DIFF
--- a/.github/workflows/languages.yml
+++ b/.github/workflows/languages.yml
@@ -76,7 +76,8 @@ jobs:
           gh pr create --fill --base ${baseBranch}
           # Avoid occasional GitHub error "Pull request Pull request is in clean status".
           sleep 1s
-          gh pr merge --auto --rebase --delete-branch
+          # Skip the check for manual revisions in the merge process.
+          gh pr merge --admin --rebase --delete-branch
 
       - name: Release base branch (if base branch was also previously released)
         if: ${{ steps.update-language-files.outputs.CHANGED_LANGUAGES && steps.update-language-files.outputs.RELEASED_BASE_BRANCH == 1 }}


### PR DESCRIPTION
Normally, a PR requires manual review before being merged into master. Skip this to enable a fully automated workflow.

Relates: #59 