### PR TITLE
FEATURE: Handle UTF-8 in HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ $syllable->setHyphen(new Hyphen\Dash());
 // By default, all words are hyphenated.
 $syllable->setMinWordLength(5);
 
-// Output hyphenated text.
+// Output hyphenated text ..
 echo $syllable->hyphenateText('Provide your own paragraphs...');
+// .. or hyphenated HTML.
+echo $syllable->hyphenateHtmlText('<b>... with highlighted text.</b>');
 ```
 
 See the [demo.php](demo.php) file for a working example.
@@ -137,7 +139,7 @@ Words need to contain at least this many character to be hyphenated.
 #### public setLibxmlOptions(int $libxmlOptions)
 
 Options to use for HTML parsing by libxml.
-See https://www.php.net/manual/de/libxml.constants.php.
+**See:** https://www.php.net/manual/de/libxml.constants.php.
 
 #### public excludeAll()
 
@@ -192,8 +194,15 @@ Hyphenate all words in the plain text.
 
 #### public hyphenateHtml(string $html): string
 
-Hyphenate all readable text in the HTML body, excluding HTML tags and
+Hyphenate all readable text in the HTML, excluding HTML tags and
 attributes.
+**Deprecated:** Use the UTF-8 capable hyphenateHtmlText() instead. This method is kept only for backward compatibility and will be removed in the next major version 2.0.
+
+#### public hyphenateHtmlText(string $html): string
+
+Hyphenate all readable text in the HTML, excluding HTML tags and
+attributes.
+This method is UTF-8 capable and should be preferred over hyphenateHtml().
 
 #### public histogramText(string $text): array
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Hyphenate all words in the plain text.
 
 #### public hyphenateHtml(string $html): string
 
-Hyphenate all readable text in the HTML, excluding HTML tags and
+Hyphenate all readable text in the HTML body, excluding HTML tags and
 attributes.
 
 #### public histogramText(string $text): array

--- a/build/classes/Reflection.php
+++ b/build/classes/Reflection.php
@@ -114,8 +114,11 @@ class Reflection
                             $annotation = explode(' ', $line);
                             $returnType = $annotation[1] !== 'void' ? $annotation[1] : '';
                         } elseif (strpos($line, '@see') === 0) {
-                            $annotation = explode(' ', $line);
-                            $commentLines[] = 'See '.$annotation[1].'.';
+                            $annotation = explode(' ', $line, 2);
+                            $commentLines[] = '**See:** '.rtrim($annotation[1], '.').'.';
+                        } elseif (strpos($line, '@deprecated') === 0) {
+                            $annotation = explode(' ', $line, 2);
+                            $commentLines[] = '**Deprecated:** '.rtrim($annotation[1], '.').'.';
                         } elseif (!empty($line)) {
                             $commentLines[] = $line;
                         }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
   "require": {
     "php": ">=5.6",
     "ext-json": "*",
+    "ext-libxml": "*",
     "ext-mbstring": "*",
     "ext-dom": "*"
   },

--- a/src/Syllable.php
+++ b/src/Syllable.php
@@ -497,8 +497,10 @@ class Syllable
     }
 
     /**
-     * Hyphenate all readable text in the HTML body, excluding HTML tags and
+     * Hyphenate all readable text in the HTML, excluding HTML tags and
      * attributes.
+     *
+     * @deprecated Use the UTF-8 capable hyphenateHtmlText() instead. This method is kept only for backward compatibility and will be removed in the next major version 2.0.
      *
      * @param string $html
      *
@@ -506,8 +508,34 @@ class Syllable
      */
     public function hyphenateHtml($html)
     {
+        $dom = new DOMDocument();
+        $dom->resolveExternals = true;
+        $dom->loadHTML($html, $this->libxmlOptions);
+
+        // filter excludes
+        $xpath = new DOMXPath($dom);
+        $excludedNodes = $this->excludes ? $xpath->query(join('|', $this->excludes)) : null;
+        $includedNodes = $this->includes ? $xpath->query(join('|', $this->includes)) : null;
+
+        $this->hyphenateHtmlDom($dom, $excludedNodes, $includedNodes);
+
+        return $dom->saveHTML();
+    }
+
+    /**
+     * Hyphenate all readable text in the HTML, excluding HTML tags and
+     * attributes.
+     *
+     * This method is UTF-8 capable and should be preferred over hyphenateHtml().
+     *
+     * @param string $html
+     *
+     * @return string
+     */
+    public function hyphenateHtmlText($html)
+    {
         $charset = mb_detect_encoding($html);
-        list($bodyContent, $beforeBodyContent, $afterBodyContent) = $this->parseHtml($html);
+        list($bodyContent, $beforeBodyContent, $afterBodyContent) = $this->parseHtmlText($html);
         $html = "<!DOCTYPE html PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN' 'http://www.w3.org/TR/REC-html40/loose.dtd'>" .
             "<html>" .
                 "<head>" .
@@ -539,7 +567,7 @@ class Syllable
      *
      * @return array
      */
-    protected function parseHtml($html)
+    private function parseHtmlText($html)
     {
         if (($bodyContentEnd = mb_strrpos($html, '</body>')) !== false) {
             $bodyContentStart = mb_strpos($html, '<body');

--- a/src/Syllable.php
+++ b/src/Syllable.php
@@ -536,13 +536,13 @@ class Syllable
     {
         $charset = mb_detect_encoding($html);
         list($bodyContent, $beforeBodyContent, $afterBodyContent) = $this->parseHtmlText($html);
-        $html = "<!DOCTYPE html PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN' 'http://www.w3.org/TR/REC-html40/loose.dtd'>" .
-            "<html>" .
-                "<head>" .
-                    "<meta http-equiv='content-type' content='text/html; charset=$charset'>" .
-                "</head>" .
-                "<body>$bodyContent</body>" .
-            "</html>";
+        $html = "<!DOCTYPE html PUBLIC '-//W3C//DTD HTML 4.0 Transitional//EN' 'http://www.w3.org/TR/REC-html40/loose.dtd'>".
+            '<html>'.
+                '<head>'.
+                    "<meta http-equiv='content-type' content='text/html; charset=$charset'>".
+                '</head>'.
+                "<body>$bodyContent</body>".
+            '</html>';
 
         $dom = new DOMDocument();
         $dom->resolveExternals = true;

--- a/tests/build/DocumentationManagerTest.php
+++ b/tests/build/DocumentationManagerTest.php
@@ -64,10 +64,15 @@ The following describes the API of the main Syllable class. In most cases,
 you will not use any other functions. Browse the code under src/ for all 
 available functions.
 
+#### public setMethodsDeprecated(array $methods = [])
+
+The deprecated public setter method.
+**Deprecated:** Use setMethods() instead.
+
 #### public setMethods(array $methods = [])
 
 The public setter method.
-See https://github.com/vanderlee/phpSyllable/blob/master/tests/build/ReflectionFixture.php.
+**See:** https://github.com/vanderlee/phpSyllable/blob/master/tests/build/ReflectionFixture.php.
 
 #### public getMethods(): array
 

--- a/tests/build/ReflectionFixture.php
+++ b/tests/build/ReflectionFixture.php
@@ -15,6 +15,20 @@ class ReflectionFixture
     protected static $parameters;
 
     /**
+     * The deprecated public setter method.
+     *
+     * @param array $methods
+     *
+     * @return void
+     *
+     * @deprecated Use setMethods() instead.
+     */
+    public function setMethodsDeprecated($methods = [])
+    {
+        $this->methods = $methods;
+    }
+
+    /**
      * The public setter method.
      *
      * @param array $methods

--- a/tests/build/ReflectionTest.php
+++ b/tests/build/ReflectionTest.php
@@ -33,8 +33,12 @@ class ReflectionTest extends AbstractTestCase
 
         $expected = [
             [
+                'signature' => 'public setMethodsDeprecated(array $methods = [])',
+                'comment'   => "The deprecated public setter method.\n**Deprecated:** Use setMethods() instead.",
+            ],
+            [
                 'signature' => 'public setMethods(array $methods = [])',
-                'comment'   => "The public setter method.\nSee https://github.com/vanderlee/phpSyllable/blob/master/tests/build/ReflectionFixture.php.",
+                'comment'   => "The public setter method.\n**See:** https://github.com/vanderlee/phpSyllable/blob/master/tests/build/ReflectionFixture.php.",
             ],
             [
                 'signature' => 'public getMethods(): array',

--- a/tests/src/SyllableTest.php
+++ b/tests/src/SyllableTest.php
@@ -558,19 +558,61 @@ class SyllableTest extends AbstractTestCase
     }
 
     /**
+     * @return array[]
+     */
+    public function dataHyphenateHtml()
+    {
+        return [
+            [
+                'Ridiculously <b class="unsplittable">complicated</b> metatext — with dash entity.',
+                'Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text — with dash en-ti-ty.',
+            ],
+            [
+                '<html>' .
+                    '<body>' .
+                        'Ridiculously <b class="unsplittable">complicated</b> metatext — with dash entity.' .
+                    '</body>' .
+                '</html>',
+                '<html>' .
+                    '<body>' .
+                        'Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text — with dash en-ti-ty.' .
+                    '</body>' .
+                '</html>',
+            ],
+            [
+                '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">' .
+                '<html>' .
+                    '<body class="body-class">' .
+                        'Ridiculously <b class="unsplittable">complicated</b> metatext — with dash entity.' .
+                    '</body>' .
+                '</html>',
+                '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">' .
+                '<html>' .
+                    '<body class="body-class">' .
+                        'Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text — with dash en-ti-ty.' .
+                    '</body>' .
+                '</html>',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataHyphenateHtml
+     *
      * @return void
      */
-    public function testHyphenateHtml()
+    public function testHyphenateHtml($html, $expected)
     {
         $this->object->setHyphen('-');
 
-        $this->assertEquals('<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
-            ."\n".'<html><body><p>Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text</p></body></html>'
-            ."\n", $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext'));
+        // Test that incoming content is never wrapped with the implicit doctype or
+        // html and body tag of DOMDocument. It always behaves as if LIBXML_HTML_NOIMPLIED
+        // and LIBXML_HTML_NODEFDTD are set.
+        $this->object->setLibxmlOptions(0);
+        $this->assertEquals($expected, $this->object->hyphenateHtml($html));
 
         $this->object->setLibxmlOptions(LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
-        $this->assertEquals('<p>Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text</p>'
-            ."\n", $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext'));
+        $this->assertEquals($expected, $this->object->hyphenateHtml($html));
     }
 
     /**
@@ -642,9 +684,7 @@ class SyllableTest extends AbstractTestCase
 
         // Do not Hypenate content within <b>
         $this->assertEquals(
-            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
-            ."\n".'<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i></p></body></html>'
-            ."\n",
+            'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i>',
             $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
         );
     }
@@ -659,9 +699,7 @@ class SyllableTest extends AbstractTestCase
 
         // Do not Hypenate content within <b>
         $this->assertEquals(
-            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
-            ."\n".'<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>extravaganza</i></p></body></html>'
-            ."\n",
+            'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>extravaganza</i>',
             $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
         );
     }
@@ -677,9 +715,7 @@ class SyllableTest extends AbstractTestCase
 
         // Do not Hypenate content within <b>
         $this->assertEquals(
-            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
-            ."\n".'<html><body><p>Ridiculously <b class="unsplittable">com-pli-cat-ed</b> metatext <i>extravaganza</i></p></body></html>'
-            ."\n",
+            'Ridiculously <b class="unsplittable">com-pli-cat-ed</b> metatext <i>extravaganza</i>',
             $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
         );
     }
@@ -695,9 +731,7 @@ class SyllableTest extends AbstractTestCase
 
         // Do not Hypenate content within <b>
         $this->assertEquals(
-            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
-            ."\n".'<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated <i>ex-trav-a-gan-za</i></b> meta-text</p></body></html>'
-            ."\n",
+            'Ridicu-lous-ly <b class="unsplittable">complicated <i>ex-trav-a-gan-za</i></b> meta-text',
             $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated <i>extravaganza</i></b> metatext')
         );
     }
@@ -712,9 +746,7 @@ class SyllableTest extends AbstractTestCase
 
         // Do not Hypenate content within <b>
         $this->assertEquals(
-            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
-            ."\n".'<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i></p></body></html>'
-            ."\n",
+            'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i>',
             $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
         );
     }
@@ -729,10 +761,30 @@ class SyllableTest extends AbstractTestCase
 
         // Do not Hypenate content within <b>
         $this->assertEquals(
-            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
-            ."\n".'<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i class="go right ahead">ex-trav-a-gan-za</i></p></body></html>'
-            ."\n",
+            'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i class="go right ahead">ex-trav-a-gan-za</i>',
             $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i class="go right ahead">extravaganza</i>')
         );
+    }
+
+    /**
+     * @return void
+     */
+    public function testUtf8Characters()
+    {
+        $this->object->setHyphen('-');
+
+        $this->object->setLanguage('de');
+        $this->assertEquals('Äu-ßerst kom-pli-zier-ter Me-ta-text.',
+            $this->object->hyphenateText('Äußerst komplizierter Metatext.')
+        );
+        $this->assertEquals('Äu-ßerst <b class="unsplittable">kom-pli-zier-ter</b> Me-ta-text.',
+            $this->object->hyphenateHtml('Äußerst <b class="unsplittable">komplizierter</b> Metatext.')
+        );
+
+        $this->object->setLanguage('uk');
+        $this->assertEquals('Над-зви-чайно скла-дний ме-та-те-кст.',
+            $this->object->hyphenateText('Надзвичайно складний метатекст.'));
+        $this->assertEquals('Над-зви-чайно <b class="unsplittable">скла-дний</b> ме-та-те-кст.',
+            $this->object->hyphenateHtml('Надзвичайно <b class="unsplittable">складний</b> метатекст.'));
     }
 }

--- a/tests/src/SyllableTest.php
+++ b/tests/src/SyllableTest.php
@@ -558,9 +558,25 @@ class SyllableTest extends AbstractTestCase
     }
 
     /**
+     * @return void
+     */
+    public function testHyphenateHtml()
+    {
+        $this->object->setHyphen('-');
+
+        $this->assertEquals('<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
+            ."\n".'<html><body><p>Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text</p></body></html>'
+            ."\n", $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext'));
+
+        $this->object->setLibxmlOptions(LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+        $this->assertEquals('<p>Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text</p>'
+            ."\n", $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext'));
+    }
+
+    /**
      * @return array[]
      */
-    public function dataHyphenateHtml()
+    public function dataHyphenateHtmlText()
     {
         return [
             [
@@ -597,11 +613,11 @@ class SyllableTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider dataHyphenateHtml
+     * @dataProvider dataHyphenateHtmlText
      *
      * @return void
      */
-    public function testHyphenateHtml($html, $expected)
+    public function testHyphenateHtmlText($html, $expected)
     {
         $this->object->setHyphen('-');
 
@@ -609,10 +625,10 @@ class SyllableTest extends AbstractTestCase
         // html and body tag of DOMDocument. It always behaves as if LIBXML_HTML_NOIMPLIED
         // and LIBXML_HTML_NODEFDTD are set.
         $this->object->setLibxmlOptions(0);
-        $this->assertEquals($expected, $this->object->hyphenateHtml($html));
+        $this->assertEquals($expected, $this->object->hyphenateHtmlText($html));
 
         $this->object->setLibxmlOptions(LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
-        $this->assertEquals($expected, $this->object->hyphenateHtml($html));
+        $this->assertEquals($expected, $this->object->hyphenateHtmlText($html));
     }
 
     /**
@@ -684,8 +700,14 @@ class SyllableTest extends AbstractTestCase
 
         // Do not Hypenate content within <b>
         $this->assertEquals(
-            'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i>',
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
+            ."\n".'<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i></p></body></html>'
+            ."\n",
             $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
+        );
+        $this->assertEquals(
+            'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i>',
+            $this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
         );
     }
 
@@ -699,8 +721,14 @@ class SyllableTest extends AbstractTestCase
 
         // Do not Hypenate content within <b>
         $this->assertEquals(
-            'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>extravaganza</i>',
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
+            ."\n".'<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>extravaganza</i></p></body></html>'
+            ."\n",
             $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
+        );
+        $this->assertEquals(
+            'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>extravaganza</i>',
+            $this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
         );
     }
 
@@ -715,8 +743,14 @@ class SyllableTest extends AbstractTestCase
 
         // Do not Hypenate content within <b>
         $this->assertEquals(
-            'Ridiculously <b class="unsplittable">com-pli-cat-ed</b> metatext <i>extravaganza</i>',
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
+            ."\n".'<html><body><p>Ridiculously <b class="unsplittable">com-pli-cat-ed</b> metatext <i>extravaganza</i></p></body></html>'
+            ."\n",
             $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
+        );
+        $this->assertEquals(
+            'Ridiculously <b class="unsplittable">com-pli-cat-ed</b> metatext <i>extravaganza</i>',
+            $this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
         );
     }
 
@@ -731,8 +765,14 @@ class SyllableTest extends AbstractTestCase
 
         // Do not Hypenate content within <b>
         $this->assertEquals(
-            'Ridicu-lous-ly <b class="unsplittable">complicated <i>ex-trav-a-gan-za</i></b> meta-text',
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
+            ."\n".'<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated <i>ex-trav-a-gan-za</i></b> meta-text</p></body></html>'
+            ."\n",
             $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated <i>extravaganza</i></b> metatext')
+        );
+        $this->assertEquals(
+            'Ridicu-lous-ly <b class="unsplittable">complicated <i>ex-trav-a-gan-za</i></b> meta-text',
+            $this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated <i>extravaganza</i></b> metatext')
         );
     }
 
@@ -746,8 +786,14 @@ class SyllableTest extends AbstractTestCase
 
         // Do not Hypenate content within <b>
         $this->assertEquals(
-            'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i>',
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
+            ."\n".'<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i></p></body></html>'
+            ."\n",
             $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
+        );
+        $this->assertEquals(
+            'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i>',
+            $this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
         );
     }
 
@@ -761,8 +807,14 @@ class SyllableTest extends AbstractTestCase
 
         // Do not Hypenate content within <b>
         $this->assertEquals(
-            'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i class="go right ahead">ex-trav-a-gan-za</i>',
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
+            ."\n".'<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i class="go right ahead">ex-trav-a-gan-za</i></p></body></html>'
+            ."\n",
             $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated</b> metatext <i class="go right ahead">extravaganza</i>')
+        );
+        $this->assertEquals(
+            'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i class="go right ahead">ex-trav-a-gan-za</i>',
+            $this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated</b> metatext <i class="go right ahead">extravaganza</i>')
         );
     }
 
@@ -778,13 +830,13 @@ class SyllableTest extends AbstractTestCase
             $this->object->hyphenateText('Äußerst komplizierter Metatext.')
         );
         $this->assertEquals('Äu-ßerst <b class="unsplittable">kom-pli-zier-ter</b> Me-ta-text.',
-            $this->object->hyphenateHtml('Äußerst <b class="unsplittable">komplizierter</b> Metatext.')
+            $this->object->hyphenateHtmlText('Äußerst <b class="unsplittable">komplizierter</b> Metatext.')
         );
 
         $this->object->setLanguage('uk');
         $this->assertEquals('Над-зви-чайно скла-дний ме-та-те-кст.',
             $this->object->hyphenateText('Надзвичайно складний метатекст.'));
         $this->assertEquals('Над-зви-чайно <b class="unsplittable">скла-дний</b> ме-та-те-кст.',
-            $this->object->hyphenateHtml('Надзвичайно <b class="unsplittable">складний</b> метатекст.'));
+            $this->object->hyphenateHtmlText('Надзвичайно <b class="unsplittable">складний</b> метатекст.'));
     }
 }

--- a/tests/src/SyllableTest.php
+++ b/tests/src/SyllableTest.php
@@ -707,7 +707,10 @@ class SyllableTest extends AbstractTestCase
         );
         $this->assertEquals(
             'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i>',
-            $this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
+            // Old libxml versions of PHP < 7.4 occasionally added a line break in the output of
+            // \DOMDocument::saveHTML(). These line breaks are not yet handled in the Syllable
+            // implementation, but only quick and dirty in these tests by removing the trailing line breaks.
+            rtrim($this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>'))
         );
     }
 
@@ -728,7 +731,10 @@ class SyllableTest extends AbstractTestCase
         );
         $this->assertEquals(
             'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>extravaganza</i>',
-            $this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
+            // Old libxml versions of PHP < 7.4 occasionally added a line break in the output of
+            // \DOMDocument::saveHTML(). These line breaks are not yet handled in the Syllable
+            // implementation, but only quick and dirty in these tests by removing the trailing line breaks.
+            rtrim($this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>'))
         );
     }
 
@@ -750,7 +756,10 @@ class SyllableTest extends AbstractTestCase
         );
         $this->assertEquals(
             'Ridiculously <b class="unsplittable">com-pli-cat-ed</b> metatext <i>extravaganza</i>',
-            $this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
+            // Old libxml versions of PHP < 7.4 occasionally added a line break in the output of
+            // \DOMDocument::saveHTML(). These line breaks are not yet handled in the Syllable
+            // implementation, but only quick and dirty in these tests by removing the trailing line breaks.
+            rtrim($this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>'))
         );
     }
 
@@ -766,13 +775,16 @@ class SyllableTest extends AbstractTestCase
         // Do not Hypenate content within <b>
         $this->assertEquals(
             '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'
-            ."\n".'<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated <i>ex-trav-a-gan-za</i></b> meta-text</p></body></html>'
+            ."\n".'<html><body><p>Ridicu-lous-ly <b class="unsplittable">complicated </b> meta-text <i>ex-trav-a-gan-za</i></p></body></html>'
             ."\n",
-            $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated <i>extravaganza</i></b> metatext')
+            $this->object->hyphenateHtml('Ridiculously <b class="unsplittable">complicated </b> metatext <i>extravaganza</i>')
         );
         $this->assertEquals(
-            'Ridicu-lous-ly <b class="unsplittable">complicated <i>ex-trav-a-gan-za</i></b> meta-text',
-            $this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated <i>extravaganza</i></b> metatext')
+            'Ridicu-lous-ly <b class="unsplittable">complicated </b> meta-text <i>ex-trav-a-gan-za</i>',
+            // Old libxml versions of PHP < 7.4 occasionally added a line break in the output of
+            // \DOMDocument::saveHTML(). These line breaks are not yet handled in the Syllable
+            // implementation, but only quick and dirty in these tests by removing the trailing line breaks.
+            rtrim($this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated </b> metatext <i>extravaganza</i>'))
         );
     }
 
@@ -793,7 +805,10 @@ class SyllableTest extends AbstractTestCase
         );
         $this->assertEquals(
             'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i>ex-trav-a-gan-za</i>',
-            $this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>')
+            // Old libxml versions of PHP < 7.4 occasionally added a line break in the output of
+            // \DOMDocument::saveHTML(). These line breaks are not yet handled in the Syllable
+            // implementation, but only quick and dirty in these tests by removing the trailing line breaks.
+            rtrim($this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated</b> metatext <i>extravaganza</i>'))
         );
     }
 
@@ -814,7 +829,10 @@ class SyllableTest extends AbstractTestCase
         );
         $this->assertEquals(
             'Ridicu-lous-ly <b class="unsplittable">complicated</b> meta-text <i class="go right ahead">ex-trav-a-gan-za</i>',
-            $this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated</b> metatext <i class="go right ahead">extravaganza</i>')
+            // Old libxml versions of PHP < 7.4 occasionally added a line break in the output of
+            // \DOMDocument::saveHTML(). These line breaks are not yet handled in the Syllable
+            // implementation, but only quick and dirty in these tests by removing the trailing line breaks.
+            rtrim($this->object->hyphenateHtmlText('Ridiculously <b class="unsplittable">complicated</b> metatext <i class="go right ahead">extravaganza</i>'))
         );
     }
 

--- a/tests/src/SyllableTest.php
+++ b/tests/src/SyllableTest.php
@@ -584,29 +584,29 @@ class SyllableTest extends AbstractTestCase
                 'Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text — with dash en-ti-ty.',
             ],
             [
-                '<html>' .
-                    '<body>' .
-                        'Ridiculously <b class="unsplittable">complicated</b> metatext — with dash entity.' .
-                    '</body>' .
+                '<html>'.
+                    '<body>'.
+                        'Ridiculously <b class="unsplittable">complicated</b> metatext — with dash entity.'.
+                    '</body>'.
                 '</html>',
-                '<html>' .
-                    '<body>' .
-                        'Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text — with dash en-ti-ty.' .
-                    '</body>' .
+                '<html>'.
+                    '<body>'.
+                        'Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text — with dash en-ti-ty.'.
+                    '</body>'.
                 '</html>',
             ],
             [
-                '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">' .
-                '<html>' .
-                    '<body class="body-class">' .
-                        'Ridiculously <b class="unsplittable">complicated</b> metatext — with dash entity.' .
-                    '</body>' .
+                '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'.
+                '<html>'.
+                    '<body class="body-class">'.
+                        'Ridiculously <b class="unsplittable">complicated</b> metatext — with dash entity.'.
+                    '</body>'.
                 '</html>',
-                '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">' .
-                '<html>' .
-                    '<body class="body-class">' .
-                        'Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text — with dash en-ti-ty.' .
-                    '</body>' .
+                '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">'.
+                '<html>'.
+                    '<body class="body-class">'.
+                        'Ridicu-lous-ly <b class="unsplittable">com-pli-cat-ed</b> meta-text — with dash en-ti-ty.'.
+                    '</body>'.
                 '</html>',
             ],
         ];
@@ -844,17 +844,23 @@ class SyllableTest extends AbstractTestCase
         $this->object->setHyphen('-');
 
         $this->object->setLanguage('de');
-        $this->assertEquals('Äu-ßerst kom-pli-zier-ter Me-ta-text.',
+        $this->assertEquals(
+            'Äu-ßerst kom-pli-zier-ter Me-ta-text.',
             $this->object->hyphenateText('Äußerst komplizierter Metatext.')
         );
-        $this->assertEquals('Äu-ßerst <b class="unsplittable">kom-pli-zier-ter</b> Me-ta-text.',
+        $this->assertEquals(
+            'Äu-ßerst <b class="unsplittable">kom-pli-zier-ter</b> Me-ta-text.',
             $this->object->hyphenateHtmlText('Äußerst <b class="unsplittable">komplizierter</b> Metatext.')
         );
 
         $this->object->setLanguage('uk');
-        $this->assertEquals('Над-зви-чайно скла-дний ме-та-те-кст.',
-            $this->object->hyphenateText('Надзвичайно складний метатекст.'));
-        $this->assertEquals('Над-зви-чайно <b class="unsplittable">скла-дний</b> ме-та-те-кст.',
-            $this->object->hyphenateHtmlText('Надзвичайно <b class="unsplittable">складний</b> метатекст.'));
+        $this->assertEquals(
+            'Над-зви-чайно скла-дний ме-та-те-кст.',
+            $this->object->hyphenateText('Надзвичайно складний метатекст.')
+        );
+        $this->assertEquals(
+            'Над-зви-чайно <b class="unsplittable">скла-дний</b> ме-та-те-кст.',
+            $this->object->hyphenateHtmlText('Надзвичайно <b class="unsplittable">складний</b> метатекст.')
+        );
     }
 }


### PR DESCRIPTION
Hi @vanderlee,

this PR is about finally handling the non-Latin, UTF-8 characters in Syllable::hyphenateHtml(). With this patch hyphenation in Syllable::hyphenateText() and Syllable::hyphenateHtml() behave the same and allow for example to hypehante html with entities or Cyrillic characters.

Greetings
Alex