### PR TITLE
FEATURE: Use `\hyphenations` case-insensitive (like `\patterns`)

### DIFF
--- a/src/Syllable.php
+++ b/src/Syllable.php
@@ -754,13 +754,30 @@ class Syllable
             return [$word];
         }
 
+        $wordLowerCased = mb_strtolower($word);
+
         // Is it a pre-hyphenated word?
-        if (isset($this->hyphenation[$word])) {
-            return mb_split('-', $this->hyphenation[$word]);
+        if (isset($this->hyphenation[$wordLowerCased])) {
+            $hyphenation = $this->hyphenation[$wordLowerCased];
+            $hyphenationLength = mb_strlen($hyphenation);
+            $parts = [];
+            $part = '';
+            for ($i = 0, $j = 0; $i < $hyphenationLength; $i++) {
+                if (mb_substr($hyphenation, $i, 1) !== '-') {
+                    $part .= mb_substr($word, $j++, 1);
+                } else {
+                    $parts[] = $part;
+                    $part = '';
+                }
+            }
+            if (!empty($part)) {
+                $parts[] = $part;
+            }
+            return $parts;
         }
 
         // Convenience array
-        $text = '.'.mb_strtolower($word).'.';
+        $text = '.'.$wordLowerCased.'.';
         $textLength = $wordLength + 2;
         $patternLength = $this->maxPattern < $textLength
             ? $this->maxPattern

--- a/tests/src/SyllableTest.php
+++ b/tests/src/SyllableTest.php
@@ -638,8 +638,13 @@ class SyllableTest extends AbstractTestCase
     {
         $this->object->setHyphen('-');
 
+        // Patterns
         $this->assertEquals(['IN', 'EX', 'PLIC', 'A', 'BLE'], $this->object->splitText('INEXPLICABLE'));
         $this->assertEquals(['in', 'ex', 'plic', 'a', 'ble'], $this->object->splitText('inexplicable'));
+
+        // Hyphenations
+        $this->assertEquals(['as', 'so', 'ciate'], $this->object->splitText('associate'));
+        $this->assertEquals(['AS', 'SO', 'CIATE'], $this->object->splitText('ASSOCIATE'));
     }
 
     /**


### PR DESCRIPTION
Hi @vanderlee, 

this patch handles syllables defined under the `\hyphenations` command case-insensitively. This corresponds to the handling of syllables defined under `\patterns`.

Greetings
Alex

Fixes: https://github.com/vanderlee/phpSyllable/issues/70
Fixes: #71 