### PR TITLE
Support pre-release semantic versioning

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,8 @@
 .github export-ignore
 build export-ignore
 tests export-ignore
-demo.php export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+demo.php export-ignore
 index.html export-ignore
 phpunit.xml export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
-/.idea
-/nbproject/private/
-/build/logs/
-/cache/
+.phpunit.result.cache
+
+/.idea/
 /nbproject/
-/debug/
-/composer.lock
 /vendor/
+/composer.lock

--- a/build/classes/SemanticVersioning.php
+++ b/build/classes/SemanticVersioning.php
@@ -11,7 +11,11 @@ class SemanticVersioning
     public function getNextReleaseTag($tag, $releaseType)
     {
         $tagPrefix = substr($tag, 0, strcspn($tag, '0123456789'));
-        $tagVersion = substr($tag, strlen($tagPrefix));
+        if (($tagSuffixPos = strpos($tag, '-')) !== false) {
+            $tagVersion = substr($tag, strlen($tagPrefix), $tagSuffixPos);
+        } else {
+            $tagVersion = substr($tag, strlen($tagPrefix));
+        }
         $tagVersionParts = explode('.', $tagVersion);
         $releaseVersionParts = $tagVersionParts + [0, 0, 0];
         $releaseVersionParts = array_slice($releaseVersionParts, 0, $releaseType + 1);

--- a/tests/build/SemanticVersioningTest.php
+++ b/tests/build/SemanticVersioningTest.php
@@ -37,6 +37,7 @@ class SemanticVersioningTest extends AbstractTestCase
             ['1', SemanticVersioning::MINOR_RELEASE, '1.1'],
             ['1', SemanticVersioning::MAJOR_RELEASE, '2'],
             ['v1.0.1', SemanticVersioning::PATCH_RELEASE, 'v1.0.2'],
+            ['1.0.1-p1', SemanticVersioning::PATCH_RELEASE, '1.0.2'],
         ];
     }
 


### PR DESCRIPTION
Hi @vanderlee ,

this patch supports the calculation of the next release tag for pre-release versions. For example this helps to automatically calculate the next release version for the recently introduced 1.7.0-p1 release.

Greetings
Alex