### PR TITLE
Fix PHP 8.4 deprecation notices updating type hints and improving test assertions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "source": "https://github.com/vanderlee/phpSyllable/"
   },
   "require": {
-    "php": ">=5.6",
+    "php": ">=7.1",
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-mbstring": "*",

--- a/src/Syllable.php
+++ b/src/Syllable.php
@@ -162,7 +162,7 @@ class Syllable
     /**
      * @param Cache $cache
      */
-    public function setCache(Cache $cache = null)
+    public function setCache(?Cache $cache = null)
     {
         $this->cache = $cache;
     }
@@ -598,8 +598,8 @@ class Syllable
      */
     private function hyphenateHtmlDom(
         DOMNode $node,
-        DOMNodeList $excludeNodes = null,
-        DOMNodeList $includeNodes = null,
+        ?DOMNodeList $excludeNodes = null,
+        ?DOMNodeList $includeNodes = null,
         $split = true
     ) {
         if ($node->hasChildNodes()) {

--- a/tests/src/SyllableTest.php
+++ b/tests/src/SyllableTest.php
@@ -171,8 +171,8 @@ class SyllableTest extends AbstractTestCase
         $this->assertNotEmpty($this->object->getCache()->__get('patterns'));
         $this->assertGreaterThan(0, $this->object->getCache()->__get('max_pattern'));
         $this->assertNotEmpty($this->object->getCache()->__get('hyphenation'));
-        $this->assertInternalType('int', $this->object->getCache()->__get('left_min_hyphen'));
-        $this->assertInternalType('int', $this->object->getCache()->__get('right_min_hyphen'));
+        $this->assertIsInt($this->object->getCache()->__get('left_min_hyphen'));
+        $this->assertIsInt($this->object->getCache()->__get('right_min_hyphen'));
     }
 
     public function dataCacheVersionMatchesCacheFileVersionIsRelaxed()


### PR DESCRIPTION
The code now uses nullable type hints for better clarity and stricter type enforcement need by PHP 8.4. 

The deprecated assertInternalType method is replaced with assertIsInt in tests to ensure compatibility with newer PHPUnit versions. 

The minimum required PHP version in the composer.json file is increased to 7.1 due to the use of nullable type hints, which are incompatible with PHP 5.6.