### PR TITLE
Modernize GitHub Actions workflows

### DIFF
--- a/.github/workflows/languages.yml
+++ b/.github/workflows/languages.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Include tags.
           fetch-depth: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
   # The runtime is only ~ 30s due to parallelization.
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: 'Run tests'
@@ -18,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Include tags.
           fetch-depth: 0
@@ -29,7 +32,7 @@ jobs:
           php-version: ${{ matrix.php }}
 
       - name: Install dependencies (using the workflow cache)
-        uses: ramsey/composer-install@v2
+        uses: ramsey/composer-install@v4
 
       - name: Run tests
         run: |
@@ -41,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP 7.4
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
## What changed
- Upgrade `actions/checkout` from v3 to v4 in the test and language-update workflows.
- Upgrade `ramsey/composer-install` from v2 to v4.
- Set the test workflow's default token permissions to read-only repository contents.

## Why
The repository already uses GitHub Actions rather than a legacy CI service, but both workflows were pinned to old major versions of core actions. Updating them reduces exposure to retired action runtimes and keeps dependency installation on its maintained release line.

## Validation
Not run locally: this environment can inspect and modify the repository through the GitHub connector but cannot clone it or execute its PHP test matrix. The draft PR should be validated by GitHub Actions before review.