### PR TITLE
Add PSR-6 cache adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ echo $syllable->hyphenateHtmlText('<b>... with highlighted text.</b>');
 
 See the [demo.php](demo.php) file for a working example.
 
+A PSR-6 cache pool can be used without changing the existing Syllable API:
+
+```php
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Vanderlee\Syllable\Cache\Psr6;
+
+$syllable->setCache(new Psr6(new FilesystemAdapter()));
+```
+
 
 ## `Syllable` API reference
 

--- a/composer.json
+++ b/composer.json
@@ -26,11 +26,12 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-mbstring": "*",
-    "ext-dom": "*"
+    "ext-dom": "*",
+    "psr/cache": "^1.0 || ^2.0 || ^3.0"
   },
   "require-dev": {
     "ext-curl": "*",
-    "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.5"
+    "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.5 || ^9.6"
   },
   "autoload": {
     "psr-4": {

--- a/src/Cache/Psr6.php
+++ b/src/Cache/Psr6.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Vanderlee\Syllable\Cache;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Adapts a PSR-6 cache pool to the Syllable cache strategy.
+ */
+class Psr6 implements Cache
+{
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $pool;
+
+    /**
+     * @var CacheItemInterface|null
+     */
+    private $item;
+
+    /**
+     * @var array
+     */
+    private $data = [];
+
+    public function __construct(CacheItemPoolInterface $pool)
+    {
+        $this->pool = $pool;
+    }
+
+    public function __set($key, $value)
+    {
+        $this->data[$key] = $value;
+    }
+
+    public function __get($key)
+    {
+        return $this->data[$key];
+    }
+
+    public function __isset($key)
+    {
+        return isset($this->data[$key]);
+    }
+
+    public function __unset($key)
+    {
+        unset($this->data[$key]);
+    }
+
+    public function open($language)
+    {
+        $this->item = $this->pool->getItem($this->getKey($language));
+        $data = $this->item->isHit() ? $this->item->get() : [];
+        $this->data = is_array($data) ? $data : [];
+    }
+
+    public function close()
+    {
+        if ($this->item === null) {
+            return;
+        }
+
+        $this->item->set($this->data);
+        $this->pool->save($this->item);
+    }
+
+    private function getKey($language)
+    {
+        return 'syllable.'.sha1(strtolower($language));
+    }
+}

--- a/tests/src/Cache/Psr6Test.php
+++ b/tests/src/Cache/Psr6Test.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Vanderlee\SyllableTest\Src\Cache;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Vanderlee\Syllable\Cache\Psr6;
+
+class Psr6Test extends TestCase
+{
+    public function testReadsAndWritesCacheData()
+    {
+        $item = $this->createMock(CacheItemInterface::class);
+        $item->expects($this->once())
+            ->method('isHit')
+            ->willReturn(true);
+        $item->expects($this->once())
+            ->method('get')
+            ->willReturn(['version' => '1.4', 'obsolete' => true]);
+        $item->expects($this->once())
+            ->method('set')
+            ->with(['version' => '1.4', 'patterns' => ['example'], 'max_pattern' => 7])
+            ->willReturnSelf();
+
+        $pool = $this->createMock(CacheItemPoolInterface::class);
+        $pool->expects($this->once())
+            ->method('getItem')
+            ->with('syllable.'.sha1('en-us'))
+            ->willReturn($item);
+        $pool->expects($this->once())
+            ->method('save')
+            ->with($item)
+            ->willReturn(true);
+
+        $cache = new Psr6($pool);
+        $cache->open('EN-US');
+
+        $this->assertTrue(isset($cache->version));
+        $this->assertSame('1.4', $cache->version);
+
+        unset($cache->obsolete);
+        $cache->patterns = ['example'];
+        $cache->max_pattern = 7;
+        $cache->close();
+    }
+
+    public function testCacheMissStartsWithEmptyData()
+    {
+        $item = $this->createMock(CacheItemInterface::class);
+        $item->expects($this->once())
+            ->method('isHit')
+            ->willReturn(false);
+        $item->expects($this->never())
+            ->method('get');
+
+        $pool = $this->createMock(CacheItemPoolInterface::class);
+        $pool->expects($this->once())
+            ->method('getItem')
+            ->willReturn($item);
+
+        $cache = new Psr6($pool);
+        $cache->open('en-us');
+
+        $this->assertFalse(isset($cache->version));
+    }
+}


### PR DESCRIPTION
## What changed

- Add a `Vanderlee\Syllable\Cache\Psr6` adapter for PSR-6 cache pools.
- Preserve the existing `Cache` strategy and `Syllable::setCache()` API.
- Support `psr/cache` versions 1, 2, and 3 so Symfony Cache and other PSR-6 implementations can be used.
- Add adapter lifecycle and cache-miss tests.
- Document Symfony Cache usage without making Symfony a runtime dependency.
- Allow PHPUnit 9.6 on modern PHP so PSR-6 v3 interfaces can be mocked, while retaining the older PHPUnit ranges for PHP 7.1.

## Why

Issue #24 proposed interchangeable internal components without breaking legacy integrations. Namespacing and the strategy interfaces are already present; this PR completes the concrete PSR-6 caching part as an additive adapter and leaves the optimized hyphenation algorithm untouched.

## Compatibility

Existing file, JSON, serialized, and custom `Cache` implementations continue to work unchanged. Applications opt into PSR-6 explicitly by passing the adapter to the existing setter.

## Validation

- `composer validate --no-check-publish --no-check-lock`
- PHPUnit functional suite: 48 tests, 121 assertions; 2 existing warnings and 2 existing incomplete tests
- PHP syntax checks for the adapter and its tests

Closes #24.
