### PR TITLE
Automate weekly language file updates

### DIFF
--- a/.github/workflows/languages.yml
+++ b/.github/workflows/languages.yml
@@ -1,90 +1,107 @@
-name: Languages
+name: Update language files
 
 on:
-  # Run manually on demand.
   workflow_dispatch:
-  # Run automatically on the first day of the month at midnight. Skip running the scheduler in forks (see job condition).
   schedule:
-    - cron: '0 0 1 * *'
+    # Check CTAN every Monday. The non-round time avoids peak scheduler load.
+    - cron: '17 6 * * 1'
+
+concurrency:
+  group: update-language-files
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   update:
-    name: 'Update languages'
+    name: Update language files
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Scheduled workflows in forks should not create update pull requests.
     if: github.event_name != 'schedule' || github.repository == 'vanderlee/phpSyllable'
-
-    permissions:
-      contents: write
-      pull-requests: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Include tags.
           fetch-depth: 0
 
       - name: Setup PHP 7.4
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
-          extensions: 'curl'
+          extensions: curl
+          coverage: none
 
-      - name: Prepare environment
-        run: |
-          git config --global user.name "Martijn van der Lee"
-          git config --global user.email "martijn@vanderlee.com"
-          
-          composer dump-autoload --dev
+      - name: Install dependencies
+        uses: ramsey/composer-install@v4
 
-      - name: Checkout new feature branch
-        run: |
-          git checkout -b "language-update-$(printf '%(%Y-%m-%d-%H-%M-%S)T')"
-
-      - name: Commit updated language files
-        id: update-language-files
-        run: |
-          baseBranch="${{ github.ref_name }}"
-          baseBranchTag="$(git describe --tags --abbrev=0 ${baseBranch})"
-          baseBranchTagLong="$(git describe --tags ${baseBranch})"
-          
-          WITH_COMMIT=1 ./build/update-language-files
-          
-          echo "CHANGED_LANGUAGES=$(git rev-list ${baseBranch}..HEAD)" >> $GITHUB_OUTPUT
-          echo "RELEASED_BASE_BRANCH=$( [ ${baseBranchTag} = ${baseBranchTagLong} ] && echo 1 || echo 0 )" >> $GITHUB_OUTPUT
-
-      - name: Commit patch release (if base branch was also previously released)
-        id: patch-release
-        if: ${{ steps.update-language-files.outputs.CHANGED_LANGUAGES && steps.update-language-files.outputs.RELEASED_BASE_BRANCH == 1 }}
-        run: |
-          WITH_COMMIT=1 ./build/create-release
-          
-          echo "RELEASE_TAG=$(git describe --tags --abbrev=0 HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Merge feature branch into base branch
-        if: ${{ steps.update-language-files.outputs.CHANGED_LANGUAGES }}
+      - name: Download current language files
+        id: languages
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          MAX_REDIRECTS: 5
+        shell: bash
         run: |
-          baseBranch="${{ github.ref_name }}"
-          featureBranch="$(git rev-parse --abbrev-ref HEAD)"
-          
-          git push --set-upstream origin ${featureBranch}
-          # Do not push the local release tag because the referenced commit changes 
-          # when it is merged with the base branch. Instead, release the base branch 
-          # via GitHub CLI after the feature branch is merged (see next step).
-          # git push --tags
-          gh pr create --fill --base ${baseBranch}
-          # Avoid occasional GitHub error "Pull request Pull request is in clean status".
-          sleep 1s
-          # Skip the check for manual revisions in the merge process.
-          gh pr merge --admin --rebase --delete-branch
+          ./build/update-language-files
 
-      - name: Release base branch (if base branch was also previously released)
-        if: ${{ steps.update-language-files.outputs.CHANGED_LANGUAGES && steps.update-language-files.outputs.RELEASED_BASE_BRANCH == 1 }}
+          if git diff --quiet -- languages; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Test updated language files
+        if: steps.languages.outputs.changed == 'true'
+        run: ./vendor/bin/phpunit
+
+      - name: Commit and push updates
+        if: steps.languages.outputs.changed == 'true'
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          UPDATE_BRANCH: automation/update-language-files
+        shell: bash
         run: |
-          baseBranch="${{ github.ref_name }}"
-          
-          gh release create ${{ steps.patch-release.outputs.RELEASE_TAG }} --target ${baseBranch}
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          git switch -C "$UPDATE_BRANCH"
+          git add languages
+          git commit -m 'Update language files'
+
+          if git ls-remote --exit-code --heads origin "$UPDATE_BRANCH" >/dev/null; then
+            git fetch origin "$UPDATE_BRANCH:refs/remotes/origin/$UPDATE_BRANCH"
+          fi
+
+          git push --force-with-lease origin "HEAD:refs/heads/$UPDATE_BRANCH"
+
+      - name: Open or refresh update pull request
+        if: steps.languages.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPDATE_BRANCH: automation/update-language-files
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+        shell: bash
+        run: |
+          pr_url="$(gh pr list --head "$UPDATE_BRANCH" --base "$BASE_BRANCH" --state open --json url --jq '.[0].url')"
+
+          if [ -z "$pr_url" ]; then
+            gh pr create \
+              --base "$BASE_BRANCH" \
+              --head "$UPDATE_BRANCH" \
+              --title 'Update language files' \
+              --body 'Automated update of the language definition files from their upstream CTAN sources.'
+          else
+            echo "Updated existing pull request: $pr_url"
+          fi
+
+      - name: Summarize result
+        env:
+          CHANGED: ${{ steps.languages.outputs.changed }}
+        shell: bash
+        run: |
+          if [ "$CHANGED" = 'true' ]; then
+            echo 'Updated language files were tested and published to the automation branch.' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'All language files are already current.' >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary

- check the upstream CTAN language definitions every Monday and on manual dispatch
- test downloaded changes before publishing them
- keep a single automation branch and open or refresh a reviewable pull request
- avoid automatically merging language updates or creating releases

## Validation

- `composer validate --no-check-publish`
- `vendor/bin/phpunit tests/src` (46 tests, 114 assertions; 2 incomplete)
- `git diff --check`

The full suite was also run locally. Its four build-test failures are existing Windows-specific line-ending/reflection differences; the language/runtime tests pass, and GitHub Actions runs the suite on Ubuntu.
