### PR TITLE
Add PHP 8.6 to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,11 @@ jobs:
   test:
     name: 'Run tests'
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.php == '8.6' }}
 
     strategy:
       matrix:
-        php: [ '7.1', '7.4', '8.2' ]
+        php: [ '7.1', '7.4', '8.2', '8.6' ]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- add PHP 8.6 to the test matrix
- keep the PHP 8.6 nightly job non-blocking while the runtime is still in development

## Impact

This provides early compatibility feedback without allowing nightly runtime regressions to block the stable PHP test suite.

## Validation

- PHP 8.6 nightly: passing
- existing stable matrix entries: passing